### PR TITLE
Significant changes for Proxy DNS and SVCB request/response handling

### DIFF
--- a/draft-proxied-svcb-headers.md
+++ b/draft-proxied-svcb-headers.md
@@ -398,10 +398,10 @@ specification to use SVCB records without performing additional DNS
 resolutions.  Clients doing so MUST implement other requirements
 specified in {{SVCB}} with the following providing a mechanism for
 doing so through a proxy.  As an example, if the client has a valid
-Proxy-DNS-SVCB header cached corresponding to a HTTPS RR, the client
-SHOULD upgrade to the "https" scheme as described in Section 3.5 of
-{{SVCB}}, which may involve abandoning a CONNECT to port 80
-through which it learned about the HTTPS RR.
+Proxy-DNS-SVCB header cached corresponding to a HTTPS RR (even if only
+for AliasMode), the client SHOULD upgrade to the "https" scheme as
+described in Section 3.5 of {{SVCB}}, which may involve abandoning a
+CONNECT to port 80 through which it learned about the HTTPS RR.
 
 If a client has a valid SVCB RRset or Proxy-DNS-SVCB cached for a
 given service, it SHOULD use CONNECT* with the authority hostname and
@@ -452,6 +452,21 @@ them as requests are made to the proxy.  Clients SHOULD periodically
 re-evaluate if new connections need to be established based on
 expiry of these TTLs.
 
+
+## SVCB-required clients
+
+SVCB-required clients must either perform additional SVCB
+DNS requests, or MUST use a proxy that is known and configured
+to always return Proxy-DNS-SVCB and Proxy-DNS-Used headers.
+
+SVCB-required clients SHOULD set high values for "wait" in
+Proxy-DNS-Request and MUST treat the absence of a Proxy-DNS-SVCB
+response header as an error.
+
+SVCB-required clients may also need to make their initial request to
+an authority with no expectation of being able to use that connection.
+Protocols specifying for SVCB-required clients will need to describe
+what clients should use in this case.
 
 
 # IANA Considerations

--- a/draft-proxied-svcb-headers.md
+++ b/draft-proxied-svcb-headers.md
@@ -1,4 +1,4 @@
-≈---
+---
 title: HTTP header fields for utilizing SVCB and HTTPS RRs via proxies
 abbrev: Proxied SVCB Headers
 docname: draft-proxied-svcb-headers-latest
@@ -78,7 +78,7 @@ for performing additional DNS lookups:
    by the proxy, allowing clients can proceed with the opportunistically
    established connection.  For services with SVCB records,
    the proxy will provide enough information to allow clients
-   to decide whether they can proceeed with using the connection
+   to decide whether they can proceed with using the connection
    or whether the client needs to establish a new connection
    through the proxy to the alternative endpoint specified
    in a SVCB record.  
@@ -179,7 +179,7 @@ HEADERS
 proxy-dns-request = "_foo.svc.example.com"; t=64; wait=400; params=(1 5); u; version=("draft-01")
 ~~~
 
-Additional examples are below in {{#examples}}.
+Additional examples are below in {#examples}.
 
 
 ## Proxy-DNS-SVCB Response Header Field {#proxy-dns-svcb}
@@ -188,7 +188,7 @@ A proxy server that receives a request with "Proxy-DNS-Request" MAY respond with
 the Structured Header "Proxy-DNS-SVCB" response header fields.
 
 The intent of this header is to provide SVCB-optional clients with
-enough information to implement {{SVCB} without performing additional
+enough information to implement {{SVCB}} without performing additional
 DNS lookups, including Sections 3 and 8.  This includes providing them
 with a list of alternative endpoints, as well as being explicit about
 whether SVCB records do and do not exist.
@@ -217,7 +217,7 @@ The TTL of the record MUST be a parameter with the key "ttl", and a value as an 
 This value must be the minimum TTL value of any CNAME or SVCB record encountered while
 resolving this SVCB record.
 
-SvcParams are represented with a parameter string contructed
+SvcParams are represented with a parameter string constructed
 prepending the string "key" to the numeric version of the
 SvcParamKey. For example, the ALPN SvcParamKey, with the numeric value
 1, would have a parameter key "key1". The value of each parameter MUST
@@ -364,18 +364,18 @@ HEADERS
 :method = CONNECT
 :status = 200
 proxy-dns-used = "svc.example.net.";ttl=7200;t=5;o="svc.example.com.",
-	         "svc2.example.net.";ttl=1800;t=5;o="svc.example.net.",
-	         "2001:db8::75";ttl=60;t=28;o="svc2.example.net."
+                 "svc2.example.net.";ttl=1800;t=5;o="svc.example.net.",
+                 "2001:db8::75";ttl=60;t=28;o="svc2.example.net."
 ~~~
 
 
 *TODO*: Do we need the "o=" parameter or is it redundant?
-	If we include it, should it be a MUST or MAY?
-	
+        If we include it, should it be a MUST or MAY?
+        
 *TODO*: Do we need to cover DNAME as well? 
 
 *TODO*: Should a future version be able to include NS record
-  	and DNSSEC information?
+        and DNSSEC information?
 
 
 # Proxy Behavior
@@ -457,9 +457,9 @@ re-evaluate if new connections need to be established based on
 expiry of these TTLs.
 
 *TODO*: Most of this section assumes ServiceMode records.
-	We should better structure to handle AliasMode records.
-	(I'm not sure the second condition ever applies?)
-	Below is some partial text:
+        We should better structure to handle AliasMode records.
+        (I'm not sure the second condition ever applies?)
+        Below is some partial text:
 
 When Proxy-DNS-SVCB (or a cached SVCB) contains an AliasMode record,
 clients SHOULD either use a connection made to the TargetName

--- a/draft-proxied-svcb-headers.md
+++ b/draft-proxied-svcb-headers.md
@@ -1,4 +1,4 @@
----
+≈---
 title: HTTP Header Fields for Proxied SVCB Metadata
 abbrev: Proxied SVCB Headers
 docname: draft-proxied-svcb-headers-latest
@@ -44,7 +44,7 @@ are supported by an endpoint. These records also can include a TLS Encrypted Cli
 {{!I-D.ietf-tls-esni}} configuration, which can be used in protecting the end-to-end TLS handshake.
 
 This document specifies HTTP header fields that proxy servers may use to relay information retrieved
-from SVCB records from proxy servers to clients when using CONNECT or CONNECT-UDP.
+from SVCB records fr≈om proxy servers to clients when using CONNECT or CONNECT-UDP.
 
 ## Requirements
 
@@ -54,8 +54,8 @@ from SVCB records from proxy servers to clients when using CONNECT or CONNECT-UD
 
 Clients can request SVCB parameters with the Structured Header
 {{!RFC8941}} "DNS-SVCB-Keys". Its value MUST
-be an sf-list whose members are sf-integer items that MUST NOT contain parameters. Its
-ABNF is:
+be an sf-list whose members are sf-integer items that MUST NOT contain parameters.
+Its ABNF is:
 
 ~~~ abnf
 DNS-SVCB-Keys = sf-list
@@ -72,6 +72,8 @@ HEADERS
 :authority = svc.example.com:443
 dns-svcb-keys = 1, 5
 ~~~
+
+
 
 # SVCB Response Header Fields {#svcb-params-response}
 
@@ -95,14 +97,14 @@ sf-integer. Alias forms, with priority 0, MUST NOT be included.
 The TTL of the record MUST be a parameter with the key "ttl", and a value as an sf-integer.
 
 Each SvcParam that matches a key requested by the client is a parameters with a key
-that is the character "p" followed by the numeric version of the SvcParamKey. For example,
-the ALPN SvcParamKey, with the numeric value 1, would have a parameter key "p1". The value
+that is the string "key" followed by the numeric version of the SvcParamKey. For example,
+the ALPN SvcParamKey, with the numeric value 1, would have a parameter key "key1". The value
 of each parameter MUST be an sf-binary item that contains the bytes of the SvcParamValue.
 
 Proxy servers MUST NOT include the "DNS-SVCB-Params" response header field if the
 corresponding request did not include a "DNS-SVCB-Keys". Servers MAY include
 specific SvcParamKey values that were not requested. Specifically, servers SHOULD include
-the "mandatory" parameter if present, which would be presented as "p0", along with any
+the "mandatory" parameter if present, which would be presented as "key0", along with any
 parameters that are defined as mandatory for that record.
 
 As an example, assume that the server received the following "svc.example.com" SVCB records:
@@ -119,8 +121,8 @@ A successful CONNECT response would include the following headers, if the client
 HEADERS
 :method = CONNECT
 :status = 200
-dns-svcb-params = "svc2.example.com.";priority=1;ttl=3600;p1=:aDIsaDM=:;p5=:MTIzLi4u:,
-                  "svc.example.com.";priority=2;ttl=3600;p1=:aDI=:;p5=:YWJjLi4u:
+dns-svcb-params = "svc2.example.com.";priority=1;ttl=3600;key1=:aDIsaDM=:;key5=:MTIzLi4u:,
+                  "svc.example.com.";priority=2;ttl=3600;key1=:aDI=:;key5=:YWJjLi4u:
 ~~~
 
 # IANA Considerations

--- a/draft-proxied-svcb-headers.md
+++ b/draft-proxied-svcb-headers.md
@@ -140,7 +140,7 @@ The item has the following parameters:
   as an sf-integer (so 64 for SVCB and 65 for HTTPS).  If not
   specified, the value of 65 (HTTPS) is the default.
 
-* wait: The maximum time the proxy should wait before responding to
+* wait: The maximum time in milliseconds the proxy should wait before responding to
   the CONNECT* request while waiting for the SVCB resolution to
   complete, specified as an sf-integer.  The proxy MAY choose to not
   wait this long before responding.  If this value is less than 1

--- a/draft-proxied-svcb-headers.md
+++ b/draft-proxied-svcb-headers.md
@@ -445,12 +445,27 @@ endpoint (if only temporarily) if it allows use of the
 opportunistically established connection, but only provided
 either condition 1 or 2 matches.
 
+If a CONNECT* request does not include a Proxy-DNS-SVCB header, and if
+clients do not have a cached SVCB RR, SVCB-optional clients SHOULD
+proceed with using the established connection.
+
 For all of the above, clients MUST age out information learned
 about Proxy-DNS-Used and Proxy-DNS-SVCB based on the TTLs
 returned in those headers.  Clients SHOULD continue to refresh
 them as requests are made to the proxy.  Clients SHOULD periodically
 re-evaluate if new connections need to be established based on
 expiry of these TTLs.
+
+*TODO*: Most of this section assumes ServiceMode records.
+	We should better structure to handle AliasMode records.
+	(I'm not sure the second condition ever applies?)
+	Below is some partial text:
+
+When Proxy-DNS-SVCB (or a cached SVCB) contains an AliasMode record,
+clients SHOULD either use a connection made to the TargetName
+of the AliasMode record, or they SHOULD use a connection
+where any of the hostnames returned in Proxy-DNS-Used
+matches the TargetName of the AliasMode record.
 
 
 ## SVCB-required clients
@@ -467,6 +482,27 @@ SVCB-required clients may also need to make their initial request to
 an authority with no expectation of being able to use that connection.
 Protocols specifying for SVCB-required clients will need to describe
 what clients should use in this case.
+
+
+## Connection coalescing
+
+*TODO*: Do we want to include text on how clients
+can also use Proxy-DNS-Used for connection coalescing?
+(One thing missing there is the full set of IP addresses
+to look for overlaps within an address family.   I'm not
+sure this is worth the complexity.  Or do we remove this
+sub-section entirely?)
+
+
+## Interaction with Alt-Svc
+
+*TODO*: Write this section...
+
+
+## Interaction with SVCB records obtained through the DNS
+
+*TODO*: Write this section...
+
 
 
 # IANA Considerations
@@ -512,6 +548,11 @@ information. Clients that depend on the contents of the SVCB record
 being DNSSEC-validated MUST NOT use this metadata without otherwise
 fetching the record and its corresponding RRSIG record and locally
 verifying its contents.
+
+Clients relying on ECH should avoid sending anything on
+opportunistically created connections until verifying whether
+there is a preferred alternative service that supports ECH
+which they should use.
 
 
 # Appendix: Additional Examples {#examples}

--- a/draft-proxied-svcb-headers.md
+++ b/draft-proxied-svcb-headers.md
@@ -71,20 +71,23 @@ This document specifies a mechanism for clients to utilize SVCB records
 through proxies supporting this specification while reducing the need
 for performing additional DNS lookups:
 
-1) Clients provide additional information in HTTP request header fields,
+1. Clients provide additional information in HTTP request header fields,
    allowing the proxy to perform appropriate SVCB lookups alongside
    its AAAA and A lookups.
-2) Proxies return HTTP response header fields specified in this
+
+2. Proxies return HTTP response header fields specified in this
    document while opportunistically establishing connections.
-3) Services with no SVCB records will be indicated as such
+
+3. Services with no SVCB records will be indicated as such
    by the proxy, allowing clients can proceed with the opportunistically
    established connection.  For services with SVCB records,
    the proxy will provide enough information to allow clients
    to decide whether they can proceed with using the connection
    or whether the client needs to establish a new connection
    through the proxy to the alternative endpoint specified
-   in a SVCB record.  
-4) For subsequent CONNECT* requests, clients provide information
+   in a SVCB record.
+
+4. For subsequent CONNECT* requests, clients provide information
    about the service name.  The proxy uses this to provide
    refreshed SVCB records, and the proxy also continues to
    provide additional information to the client about how

--- a/draft-proxied-svcb-headers.md
+++ b/draft-proxied-svcb-headers.md
@@ -57,11 +57,13 @@ target IP addresses. The records can be used to determine which application-leve
 are supported by an endpoint. These records also can include a TLS Encrypted Client Hello
 {{!I-D.ietf-tls-esni}} configuration, which can be used in protecting the end-to-end TLS handshake.
 
-Performing a separate DNS resolution for SVCB records may not make
-sense for some clients: 1) this adds a performance penalty for clients
-to perform the DNS lookup even when SVCB records aren't present, as
-normally only the proxy is performing a DNS lookup; 2) if the client
-is using the proxy for providing additional privacy, performing
+It is not always optimal for client that want to use SVCB to perform a separate
+DNS resolution prior to using a CONNECT* proxy, for a couple reasons:
+
+1. The extra DNS lookup incurs a performance penalty in delaying the client's
+connection establishment, which might be wasted if there aren't any SVCB records present.
+
+2. If the client is using the proxy for providing additional privacy, performing
 DNS lookups not through the proxy might disclose the client's destination
 to an additional party.
 


### PR DESCRIPTION
Significant changes and clarifications, renaming the existing headers and ending up with three headers:

    * Proxy-DNS-Request
    * Proxy-DNS-SVCB
    * Proxy-DNS-Used
   
Also specify client behavior to allow SVCB-optional clients to use proxies implementing these features while incorporating performance optimizations.