### PR TITLE
Describe how to instantiate motivating use cases

### DIFF
--- a/draft-private-access-tokens.md
+++ b/draft-private-access-tokens.md
@@ -663,11 +663,11 @@ budget was exceeded.
 ## Client Geo-Location {#implement-geolocation}
 
 To instantiate this use case, the Issuer has an issuing key pair per geographic region, i.e.,
-each region has a unique policy key. The Mediator forwards information about the Client's
-geographic location in a "Sec-CH-Geohash" header to the Issuer during issuance. The Issuer
-uses this location information to select the correct policy key. The number of key pairs
-is then the cross product of the number of Origins that require per-region keys and the number
-of regions.
+each region has a unique policy key. When verifying the key for the Client request, the Mediator
+obtains the per-region key from the Issuer based on the Client's perceived location. During
+issuance, the Mediator checks that this key matches that of the Client's request. If it matches,
+the Mediator forwards the request to complete issuance. The number of key pairs is then the cross
+product of the number of Origins that require per-region keys and the number of regions.
 
 During redemption, Clients present their geographic location to Origins in a "Sec-CH-Geohash"
 header. Origins use this to obtain the appropriate policy verification key. Origins request

--- a/draft-private-access-tokens.md
+++ b/draft-private-access-tokens.md
@@ -494,8 +494,8 @@ or support, it MUST reject the request with an HTTP 400 error.
 
 Before forwarding the Client's request to the Issuer, the Mediator adds headers
 listing both the ANON_CLIENT_ID as "Anonymous-Client-ID", and the ANON_ORIGIN_ID_PRIME as
-"Anonymous-Origin-ID". The Mediator MAY add additional context information about Clients,
-such as their geographic region encapsulated in a "Sec-CH-Geohash" header {{!I-D.ietf-geohash-hint}}.
+"Anonymous-Origin-ID". The mediator MAY also add additional context information, but MUST
+NOT add information that will uniquely identify a client.
 
 ~~~
 :method = POST


### PR DESCRIPTION
I don't love the geolocation exchange here. Mediators probably should not send anything that client's don't want them to send, so maybe that means clients opt-in to allowing their geohash to be forwarded. And maybe they decide to do that if Origins request tokens that need to be region specific? (Origins could maybe send that via the Accept-CH header in their challenge, and Clients could use that to send to the Mediator? I dunno.)

I also cut Client Linking as a use case.