### PR TITLE
ORIGIN_TOKEN_KEY rotation deployment info

### DIFF
--- a/draft-private-access-tokens.md
+++ b/draft-private-access-tokens.md
@@ -1038,7 +1038,7 @@ but should be avoided where hiding origins from the mediator is desirable.
 
 # Origin Key Rollout
 
-Issuers must generate a new keypair representing (ORIGIN_TOKEN_KEY,ORIGIN_SECRET) each policy window. During generation, issuers must ensure the `token_key_id` (the 8-bit prefix of SHA256(ORIGIN_TOKEN_KEY) ), is different from the current signing `token_key_id` for that origin. The issuer should regenerate the new keypair until the `token_key_id` doesn't collide with the current `token_key_id`.
+Issuers SHOULD generate a new (ORIGIN_TOKEN_KEY, ORIGIN_SECRET) regularly, and SHOULD maintain old and new secrets to allow for graceful updates. The RECOMMENDED rotation interval is two times the length of the policy window for that information. During generation, issuers must ensure the `token_key_id` (the 8-bit prefix of SHA256(ORIGIN_TOKEN_KEY) is different from all other `token_key_id` values for that origin current in rotation. One way to ensure this uniqueness is via rejection sampling.
 
 Issuers should ensure they generate this key at the begining of the new policy window, and advertise it to origins for the entire length of the current policy window. Origins must attempt to verify with both this next ORIGIN_TOKEN_KEY and the current ORIGIN_TOKEN_KEY.
 

--- a/draft-private-access-tokens.md
+++ b/draft-private-access-tokens.md
@@ -1040,7 +1040,6 @@ but should be avoided where hiding origins from the mediator is desirable.
 
 Issuers SHOULD generate a new (ORIGIN_TOKEN_KEY, ORIGIN_SECRET) regularly, and SHOULD maintain old and new secrets to allow for graceful updates. The RECOMMENDED rotation interval is two times the length of the policy window for that information. During generation, issuers must ensure the `token_key_id` (the 8-bit prefix of SHA256(ORIGIN_TOKEN_KEY) is different from all other `token_key_id` values for that origin current in rotation. One way to ensure this uniqueness is via rejection sampling.
 
-Issuers should ensure they generate this key at the begining of the new policy window, and advertise it to origins for the entire length of the current policy window. Origins must attempt to verify with both this next ORIGIN_TOKEN_KEY and the current ORIGIN_TOKEN_KEY.
 
 # IANA Considerations {#iana}
 

--- a/draft-private-access-tokens.md
+++ b/draft-private-access-tokens.md
@@ -1036,9 +1036,11 @@ but should be avoided where hiding origins from the mediator is desirable.
 
 # Deployment Considerations {#deploy}
 
-# Issuer Key Rollout
+# Origin Key Rollout
 
-TODO(smhendrickson): Issuers need to advertise new keys, and communicate the 'safe' rollout period before using them to sign. Verifiers need to check with both keys.
+Issuers must generate a new keypair representing (ORIGIN_TOKEN_KEY,ORIGIN_SECRET) each policy window. During generation, issuers must ensure the `token_key_id` (the 8-bit prefix of SHA256(ORIGIN_TOKEN_KEY) ), is different from the current signing `token_key_id` for that origin. The issuer should regenerate the new keypair until the `token_key_id` doesn't collide with the current `token_key_id`.
+
+Issuers should ensure they generate this key at the begining of the new policy window, and advertise it to origins for the entire length of the current policy window. Origins must attempt to verify with both this next ORIGIN_TOKEN_KEY and the current ORIGIN_TOKEN_KEY.
 
 # IANA Considerations {#iana}
 

--- a/draft-private-access-tokens.md
+++ b/draft-private-access-tokens.md
@@ -1038,7 +1038,13 @@ but should be avoided where hiding origins from the mediator is desirable.
 
 # Origin Key Rollout
 
-Issuers SHOULD generate a new (ORIGIN_TOKEN_KEY, ORIGIN_SECRET) regularly, and SHOULD maintain old and new secrets to allow for graceful updates. The RECOMMENDED rotation interval is two times the length of the policy window for that information. During generation, issuers must ensure the `token_key_id` (the 8-bit prefix of SHA256(ORIGIN_TOKEN_KEY) is different from all other `token_key_id` values for that origin current in rotation. One way to ensure this uniqueness is via rejection sampling.
+Issuers SHOULD generate a new (ORIGIN_TOKEN_KEY, ORIGIN_SECRET) regularly, and
+SHOULD maintain old and new secrets to allow for graceful updates. The RECOMMENDED
+rotation interval is two times the length of the policy window for that
+information. During generation, issuers must ensure the `token_key_id` (the 8-bit
+prefix of SHA256(ORIGIN_TOKEN_KEY) is different from all other `token_key_id`
+values for that origin currently in rotation. One way to ensure this uniqueness
+is via rejection sampling.
 
 
 # IANA Considerations {#iana}


### PR DESCRIPTION
This brings up a few more questions:
 - Should we update the API Endpoints section to contain APIs for querying these keys per origin?
 - Does the ISSUER_KEY need a well defined rotation policy?

#57 related