### PR TITLE
Fix issuance request binding

### DIFF
--- a/draft-private-access-tokens.md
+++ b/draft-private-access-tokens.md
@@ -647,10 +647,10 @@ operation:
 
 - RSA Blind Signatures {{BLINDSIG}}, for issuing and constructing Tokens as described in {{redemption}}.
 
-- Schnorr signatures, as described in {{!RFC8032}}, for verifying correctness of Client requests.
+- Ed25519 signatures, as described in {{!RFC8032}}, for verifying correctness of Client requests.
 
 Clients and Issuers are required to implement all of these dependencies, whereas Mediators are required
-to implement Schnorr signature support.
+to implement Ed25519 signature support.
 
 ## State Requirements
 

--- a/draft-private-access-tokens.md
+++ b/draft-private-access-tokens.md
@@ -1029,9 +1029,9 @@ aad = concat(encode(1, keyID),
              encode(2, kdfID),
              encode(2, aeadID),
              encode(1, version),
-             encode(32, request_key),
              encode(1, token_key_id),
              encode(Nk, blinded_req),
+             encode(32, request_key),
              encode(32, issuer_key_id))
 ct = context.Seal(aad, origin_name)
 encrypted_origin_name = concat(enc, ct)
@@ -1048,9 +1048,9 @@ aad = concat(encode(1, keyID),
              encode(2, kdfID),
              encode(2, aeadID),
              encode(1, version),
-             encode(32, request_key),
              encode(1, token_key_id),
              encode(Nk, blinded_req),
+             encode(32, request_key),
              encode(32, issuer_key_id))
 enc, context = SetupBaseR(enc, skI, "AccessTokenRequest")
 origin_name, error = context.Open(aad, ct)


### PR DESCRIPTION
The gist of the request generation process is now:

1. Generate a blinded token request;
2. Generate a blinded key pair;
3. Encrypt the origin name, using (1) and (2) as AAD.
4. Generate a signature covering (1-3).

The signature is just Ed25519, and the blinded key pair is just a randomized Ed25519 key pair. 

cc @FredericJacobs 