### PR TITLE
Drop OHTTP dependency and redefine the name configuration

### DIFF
--- a/draft-privacypass-rate-limit-tokens.md
+++ b/draft-privacypass-rate-limit-tokens.md
@@ -259,7 +259,7 @@ struct {
   HpkePublicKey public_key;
   HpkeKdfId kdf_id;
   HpkeAeadId aead_id;
-} NameKeNameKeyyConfig;
+} NameKey;
 ~~~
 
 The Issuer parameters can be obtained from an Issuer via a directory object, which is a JSON

--- a/draft-privacypass-rate-limit-tokens.md
+++ b/draft-privacypass-rate-limit-tokens.md
@@ -244,7 +244,7 @@ Issuers MUST provide three parameters for configuration:
    For example, an Issuer URL might be https://issuer.example.net/token-request. This parameter
    uses resource media type "text/plain".
 1. Origin Name Key: a `NameKey` structure as defined below to use when encrypting the Origin
-   Name in issuance requests. This parameter uses resource media type "application/pat-name-key".
+   Name in issuance requests. This parameter uses resource media type "application/issuer-name-key".
    The Npk parameter corresponding to the HpkeKdfId can be found in {{HPKE}}.
 
 ~~~


### PR DESCRIPTION
The NameKey fully defines the algorithms and key used for encrypting origins, as well as the corresponding key ID. Clients use these keys entirely or not, meaning there's no client-side negotiation. Since the key ID fully defines the key and algorithms, clients do not need to convey anything beyond the key ID to issuers in their TokenRequest.

Closes #124.
Closes #112. 