### PR TITLE
Align origin_name with auth scheme, allow for empty name

### DIFF
--- a/draft-privacypass-rate-limit-tokens.md
+++ b/draft-privacypass-rate-limit-tokens.md
@@ -800,7 +800,9 @@ origin_name, error = context.Open(aad, ct)
 
 The resulting value of origin_name is used by the Issuer to determine which rate-limit values
 to send to the Attester for enforcement. If the decrypted origin_name is the empty string "",
-the Issuer applies a cross-origin rate-limit policy, if supported.
+the Issuer applies a cross-origin rate-limit policy, if supported. If the decrypted origin_name
+is the empty string "" and the Issuer does not support cross-origin rate limiting, then it MUST
+abort the protocol as described in {{request-two}}.
 
 # Anonymous Issuer Origin ID Computation {#anon-issuer-origin-id}
 

--- a/draft-privacypass-rate-limit-tokens.md
+++ b/draft-privacypass-rate-limit-tokens.md
@@ -642,7 +642,7 @@ Token Keys and Origin Name Keys held by the Issuer.
 Issuer's private key (the private key associated with Origin Name Key), and matches
 an Origin Name that is served by the Issuer. This name might be the empty string "",
 as described in {{encrypt-origin}}, in which case the Issuer applies a cross-origin
-policy if allowed.
+policy if supported. If a cross-origin policy is not supported, this condition is not met.
 - The TokenRequest.blinded_msg is of the correct size
 
 If any of these conditions is not met, the Issuer MUST return an HTTP 400 error to the Attester,

--- a/draft-privacypass-rate-limit-tokens.md
+++ b/draft-privacypass-rate-limit-tokens.md
@@ -745,7 +745,7 @@ Encrypted Origin Name (`encrypted_origin`).
 
 `origin_name` contains the name of the origin that initiated the challenge, as
 taken from the TokenChallenge.origin_info field. If the TokenChallenge.origin_info field
-is empty, `origin_name` is set to a fixed string "EmptyOrigin".
+is empty, `origin_name` is set to the empty string "".
 
 The process for generating `encrypted_origin` from `origin_name` is as follows:
 

--- a/draft-privacypass-rate-limit-tokens.md
+++ b/draft-privacypass-rate-limit-tokens.md
@@ -640,7 +640,9 @@ Upon receipt of the forwarded request, the Issuer validates the following condit
 Token Keys and Origin Name Keys held by the Issuer.
 - The TokenRequest.encrypted_origin_name can be decrypted using the
 Issuer's private key (the private key associated with Origin Name Key), and matches
-an Origin Name that is served by the Issuer
+an Origin Name that is served by the Issuer. This name might be the empty string "",
+as described in {{encrypt-origin}}, in which case the Issuer applies a cross-origin
+policy if allowed.
 - The TokenRequest.blinded_msg is of the correct size
 
 If any of these conditions is not met, the Issuer MUST return an HTTP 400 error to the Attester,
@@ -795,6 +797,10 @@ aad = concat(encode(1, keyID),
 enc, context = SetupBaseR(enc, skI, "TokenRequest")
 origin_name, error = context.Open(aad, ct)
 ~~~
+
+The resulting value of origin_name is used by the Issuer to determine which rate-limit values
+to send to the Attester for enforcement. If the decrypted origin_name is the empty string "",
+the Issuer applies a cross-origin rate-limit policy, if supported.
 
 # Anonymous Issuer Origin ID Computation {#anon-issuer-origin-id}
 

--- a/draft-privacypass-rate-limit-tokens.md
+++ b/draft-privacypass-rate-limit-tokens.md
@@ -311,7 +311,7 @@ to the Issuer. If the TokenChallenge.origin_info field contains a single
 origin name, that origin name is used. If the origin_info field contains
 multiple origin names, the client selects the single origin name that
 presented the challenge. If the origin_info field is empty, the
-encrypted message uses a special value, defined in {{encrypt-origin}}.
+encrypted message is the empty string "".
 
 The HTTP authentication challenge also SHOULD contain the following
 additional attribute:


### PR DESCRIPTION
Closes #147 
Closes #187 