### PR TITLE
First take on proxy auth hint

### DIFF
--- a/draft-ietf-intarea-proxy-config.md
+++ b/draft-ietf-intarea-proxy-config.md
@@ -206,7 +206,7 @@ provided below.
 authentication methods by the SOCKS proxy. Valid values of methods are listed
 in corresponding IANA registry {{?SOCKS-METHODS=IANA.socks-methods}}.
 
-`http-schemes` MUST NOT be provided if authenticaiton method is not set to `http-proxy`.
+`http-schemes` MUST NOT be provided if authentication method is not set to `http-proxy`.
 `http-schemes` contains a list of strings representing supported authentication
 scheme names from corresponding IANA registry {{?HTTP-SCHEMES=IANA.http-authschemes}}.
 


### PR DESCRIPTION
Here is my first stab at authentication hints.

Key use case is to allow client proxy selection based on supported authentication methods.

For example, enterprise environment could have an IoT device that is only capable of TLS PSK, a workload that would like to do non-interactive mTLS authentication and an end user device that is happy to do an interactive authentication flow using HTTP methods. All these endpoints could obtain the same information about available proxies and select a proxy that is best suited to their capabilities and preferences.