### PR TITLE
Added mandatory key

### DIFF
--- a/draft-ietf-intarea-proxy-config.md
+++ b/draft-ietf-intarea-proxy-config.md
@@ -160,7 +160,7 @@ use of a proxy.
 
 Optional keys included in this or future specifications MAY be included
 in the `mandatory` list. Clients that do not recognize a key from the `mandatory`
-list or fully process corresponding sub-dictionary entry MUST ignore the entire proxy
+list or cannot fully process the corresponding sub-dictionary entry MUST ignore the entire proxy
 definition, since the proxy might be only applicable for particular uses. These keys are
 registered in an IANA registry, defined in {{proxy-info-iana}}. `mandatory` list MUST NOT
 include any entries that do not correspond to optional keys in the sub-dictionary.

--- a/draft-ietf-intarea-proxy-config.md
+++ b/draft-ietf-intarea-proxy-config.md
@@ -165,10 +165,10 @@ use of a proxy.
 | alpn | Yes | An array of Application-Layer Protocol Negotiation protocol identifiers | Array of Strings | ["h3","h2"] |
 | mandatory | Yes | An array of optional keys that client must understand and process to use this proxy | Array of Strings | ["matchDomains"] |
 
-The value of the `mandatory` key is a list of keys that the client must understand and process to be 
-able to use the proxy. A client that does not understand a key from the list or cannot fully process 
-the value of a key from the list MUST ignore the entire proxy definition. The list can contain 
-only keys that are registered in an IANA registry, defined in {{proxy-info-iana}} and that are marked 
+The value of the `mandatory` key is a list of keys that the client must understand and process to be
+able to use the proxy. A client that does not understand a key from the list or cannot fully process
+the value of a key from the list MUST ignore the entire proxy definition. The list can contain
+only keys that are registered in an IANA registry, defined in {{proxy-info-iana}} and that are marked
 as optional.  The `mandatory` list MUST NOT include any entries that are not present in the sub-dictionary.
 
 The values for the `protocol` key are defined in the proxy protocol

--- a/draft-ietf-intarea-proxy-config.md
+++ b/draft-ietf-intarea-proxy-config.md
@@ -154,18 +154,23 @@ Each proxy is defined by a proxy protocol, a proxy location (i.e., a hostname an
 
 This document defines two mandatory keys for the sub-dictionaries in the
 `proxies` array, `protocol` and `proxy`. There are also optional keys, including
-`alpn`, and destination accessibility keys defined in {{destinations}}.
-Other optional keys can be added to the dictionary
-to further define or restrict the use of a proxy. Clients that do not
-recognize or understand a key in a proxy sub-dictionary MUST ignore the entire
-proxy definition, since the proxy might be only applicable for particular
-uses. These keys are registered in an IANA registry, defined in {{proxy-info-iana}}.
+`alpn`, `mandatory`, and destination accessibility keys defined in {{destinations}}.
+Other optional keys can be added to the dictionary to further define or restrict the
+use of a proxy.
+
+Optional keys included in this or future specifications MAY be included
+in the `mandatory` list. Clients that do not recognize a key from the `mandatory`
+list or fully process corresponding sub-dictionary entry MUST ignore the entire proxy
+definition, since the proxy might be only applicable for particular uses. These keys are
+registered in an IANA registry, defined in {{proxy-info-iana}}. `mandatory` list MUST NOT
+include any entries that do not correspond to optional keys in the sub-dictionary.
 
 | JSON Key | Optional | Description | Type | Example |
 | --- | --- | --- | --- | --- |
 | protocol | No | The protocol used to communicate with the proxy | String | "connect-udp" |
 | proxy | No | String containing the URI template or hostname and port of the proxy, depending on the format defined by the protocol | String | "https://proxy.example.org:4443/masque{?target_host,target_port}" |
 | alpn | Yes | An array of Application-Layer Protocol Negotiation protocol identifiers | Array of Strings | ["h3","h2"] |
+| mandatory | Yes | An array of optional keys that client must understand and process to use this proxy | Array of Strings | ["matchDomains"] |
 
 The values for the `protocol` key are defined in the proxy protocol
 registry ({{proxy-protocol-iana}}), with the initial contents provided below.

--- a/draft-ietf-intarea-proxy-config.md
+++ b/draft-ietf-intarea-proxy-config.md
@@ -165,12 +165,6 @@ use of a proxy.
 | alpn | Yes | An array of Application-Layer Protocol Negotiation protocol identifiers | Array of Strings | ["h3","h2"] |
 | mandatory | Yes | An array of optional keys that client must understand and process to use this proxy | Array of Strings | ["matchDomains"] |
 
-The value of the `mandatory` key is a list of keys that the client must understand and process to be
-able to use the proxy. A client that does not understand a key from the list or cannot fully process
-the value of a key from the list MUST ignore the entire proxy definition. The list can contain
-only keys that are registered in an IANA registry, defined in {{proxy-info-iana}} and that are marked
-as optional.  The `mandatory` list MUST NOT include any entries that are not present in the sub-dictionary.
-
 The values for the `protocol` key are defined in the proxy protocol
 registry ({{proxy-protocol-iana}}), with the initial contents provided below.
 For consistency, any new proxy types that use HTTP Upgrade Tokens (and use
@@ -192,6 +186,12 @@ The types defined here either use a hostname and port, or a full URI template.
 If the `alpn` key is present, it provides a hint for the Application-Layer Protocol Negotiation
 (ALPN) {{!ALPN=RFC7301}} protocol identifiers associated with this server. For HTTP proxies,
 this can indicate if the proxy supports HTTP/3, HTTP/2, etc.
+
+The value of the `mandatory` key is a list of keys that the client must understand and process to be
+able to use the proxy. A client that does not understand a key from the list or cannot fully process
+the value of a key from the list MUST ignore the entire proxy definition. The list can contain
+only keys that are registered in an IANA registry, defined in {{proxy-info-iana}} and that are marked
+as optional.  The `mandatory` list MUST NOT include any entries that are not present in the sub-dictionary.
 
 When a PvD that contains the `proxies` key is fetched from a known proxy
 using the method described in {{proxy-pvd}} the proxies list describes

--- a/draft-ietf-intarea-proxy-config.md
+++ b/draft-ietf-intarea-proxy-config.md
@@ -165,12 +165,11 @@ use of a proxy.
 | alpn | Yes | An array of Application-Layer Protocol Negotiation protocol identifiers | Array of Strings | ["h3","h2"] |
 | mandatory | Yes | An array of optional keys that client must understand and process to use this proxy | Array of Strings | ["matchDomains"] |
 
-Optional keys included in this or future specifications MAY be included
-in the `mandatory` list. Clients that do not recognize a key from the `mandatory`
-list or cannot fully process the corresponding sub-dictionary entry MUST ignore the entire proxy
-definition, since the proxy might be only applicable for particular uses. These keys are
-registered in an IANA registry, defined in {{proxy-info-iana}}. `mandatory` list MUST NOT
-include any entries that do not correspond to optional keys in the sub-dictionary.
+The value of the `mandatory` key is a list of keys that the client must understand and process to be 
+able to use the proxy. A client that does not understand a key from the list or cannot fully process 
+the value of a key from the list MUST ignore the entire proxy definition. The list can contain 
+only keys that are registered in an IANA registry, defined in {{proxy-info-iana}} and that are marked 
+as optional.  The `mandatory` list MUST NOT include any entries that are not present in the sub-dictionary.
 
 The values for the `protocol` key are defined in the proxy protocol
 registry ({{proxy-protocol-iana}}), with the initial contents provided below.

--- a/draft-ietf-intarea-proxy-config.md
+++ b/draft-ietf-intarea-proxy-config.md
@@ -158,19 +158,19 @@ This document defines two mandatory keys for the sub-dictionaries in the
 Other optional keys can be added to the dictionary to further define or restrict the
 use of a proxy.
 
-Optional keys included in this or future specifications MAY be included
-in the `mandatory` list. Clients that do not recognize a key from the `mandatory`
-list or cannot fully process the corresponding sub-dictionary entry MUST ignore the entire proxy
-definition, since the proxy might be only applicable for particular uses. These keys are
-registered in an IANA registry, defined in {{proxy-info-iana}}. `mandatory` list MUST NOT
-include any entries that do not correspond to optional keys in the sub-dictionary.
-
 | JSON Key | Optional | Description | Type | Example |
 | --- | --- | --- | --- | --- |
 | protocol | No | The protocol used to communicate with the proxy | String | "connect-udp" |
 | proxy | No | String containing the URI template or hostname and port of the proxy, depending on the format defined by the protocol | String | "https://proxy.example.org:4443/masque{?target_host,target_port}" |
 | alpn | Yes | An array of Application-Layer Protocol Negotiation protocol identifiers | Array of Strings | ["h3","h2"] |
 | mandatory | Yes | An array of optional keys that client must understand and process to use this proxy | Array of Strings | ["matchDomains"] |
+
+Optional keys included in this or future specifications MAY be included
+in the `mandatory` list. Clients that do not recognize a key from the `mandatory`
+list or cannot fully process the corresponding sub-dictionary entry MUST ignore the entire proxy
+definition, since the proxy might be only applicable for particular uses. These keys are
+registered in an IANA registry, defined in {{proxy-info-iana}}. `mandatory` list MUST NOT
+include any entries that do not correspond to optional keys in the sub-dictionary.
 
 The values for the `protocol` key are defined in the proxy protocol
 registry ({{proxy-protocol-iana}}), with the initial contents provided below.


### PR DESCRIPTION
This makes format extensible in the future and allows proprietary extensions.
On top of that it addresses the question of what clients should do if they cannot fully process proxy destination restrictions. If corresponding key is in `mandatory` list, they must ignore the proxy, otherwise they may proceed even without full processing of the destination restriction list.