### PR TITLE
Clarify which port to fetch the PvD on

### DIFF
--- a/draft-ietf-intarea-proxy-config.md
+++ b/draft-ietf-intarea-proxy-config.md
@@ -114,9 +114,7 @@ issues an HTTP GET request for the well-known PvD URI (".well-known/pvd") {{PVDD
 and the host authority of the proxy. This is applicable for both proxies that are identified
 by a host and port only (such as SOCKS proxies and HTTP CONNECT proxies) and proxies
 that are identified by a URI or URI template. The fetch MUST use the "https" scheme
-and the default port for HTTP over TLS, 443. This is done because an HTTP CONNECT
-proxy running on a non-default port generally is accessed without TLS to the proxy,
-and thus would not be allowed to be used for the PvD fetch.
+and the default port for HTTP over TLS, 443.
 
 For example, a client would issue the following request for the PvD associated
 with "https://proxy.example.org/masque{?target_host,target_port}":

--- a/draft-ietf-intarea-proxy-config.md
+++ b/draft-ietf-intarea-proxy-config.md
@@ -113,7 +113,10 @@ In order to fetch PvD Additional Information associated with a proxy, a client
 issues an HTTP GET request for the well-known PvD URI (".well-known/pvd") {{PVDDATA}}
 and the host authority of the proxy. This is applicable for both proxies that are identified
 by a host and port only (such as SOCKS proxies and HTTP CONNECT proxies) and proxies
-that are identified by a URI or URI template.
+that are identified by a URI or URI template. The fetch MUST use the "https" scheme
+and the default port for HTTP over TLS, 443. This is done because an HTTP CONNECT
+proxy running on a non-default port generally is accessed without TLS to the proxy,
+and thus would not be allowed to be used for the PvD fetch.
 
 For example, a client would issue the following request for the PvD associated
 with "https://proxy.example.org/masque{?target_host,target_port}":
@@ -126,18 +129,12 @@ with "https://proxy.example.org/masque{?target_host,target_port}":
 accept = application/pvd+json
 ~~~
 
-As another example, a client would send the following request for the PvD
-assocated with an HTTP CONNECT proxy on "proxy.example.org:8080":
+A client would send the same request as above for the PvD
+assocated with an HTTP CONNECT proxy on "proxy.example.org:8080".
+Note that the client will not make a request to port 8080, but
+to port 443.
 
-~~~
-:method = GET
-:scheme = https
-:authority = proxy.example.org:8080
-:path = /.well-known/pvd
-accept = application/pvd+json
-~~~
-
-Note that all proxies that are colocated on the same host and port share the same PvD
+Note that all proxies that are co-located on the same host share the same PvD
 Additional Information. Proxy deployments that need separate PvD configuration properties
 SHOULD use different hosts.
 


### PR DESCRIPTION
Closes #288 

Fixes a bug in the spec where in an example, we showed fetching the PvD from a non-TLS port. We need to use a single PvD config per hostname.