### PR TITLE
Clarified limited use of proxies with the identifier

### DIFF
--- a/draft-ietf-intarea-proxy-config.md
+++ b/draft-ietf-intarea-proxy-config.md
@@ -249,7 +249,9 @@ across different proxy dictionaries in the `proxies` array, which indicates
 that all references from other dictionaries to a particular identifier value apply
 to all matching proxies. Proxies without the `identifier` key are expected to accept any
 traffic since their destinations cannot be contained in `proxy-match` array defined
-in {{destinations}}.
+in {{destinations}}. Proxies with `identifier` keys are expected to accept only traffic
+matching rules in the `proxy-match` array and SHOULD NOT be used if they are not included in
+the `proxy-match` array.
 
 ## Proprietary keys in proxy configurations {#proxy-proprietary-keys}
 


### PR DESCRIPTION
Addresses feedback from Philip Lisiecki:

>> The value of identifier key is a string that can be used to refer to a particular proxy from other dictionaries, specifically those defined in Section 4.

> It is unclear whether an entry with an identifier is allowed to be used even if there is no relevant proxy-match. E.g., is the intent something like "Proxies with an identifier key SHOULD only be used when a proxy-match applies"? Or is it meant to be more vague in some way?