### PR TITLE
Removed confusing "Comma-separated list"

### DIFF
--- a/draft-ietf-intarea-proxy-config.md
+++ b/draft-ietf-intarea-proxy-config.md
@@ -367,7 +367,7 @@ names prior to proxying.
 The `ports` array includes specific ports (used for matching TCP and/or UDP ports), as well as
 ranges of ports written with a low port value and a high port value, with a `-` in between.
 For example, "1024-2048" matches all ports from 1024 to 2048, including the 1024 and 2048.
-If `ports` key is not present, all ports are assumed to match. Comma-separated port list may
+If `ports` key is not present, all ports are assumed to match. The list may
 contain individual port numbers (such as "80") or inclusive ranges of ports. For example
 "1024-2048" matches all ports from 1024 to 2048, including the 1024 and 2048.
 


### PR DESCRIPTION
Addresses following feedback from Philip Lisiecki:

>> Comma-separated port list may contain individual port numbers...

> The explicit mention of "comma" makes me think that ["80,443,12345"] might be supported in addition to a standard JSON list ["80","443","12345"].