### PR TITLE
Clarify that client DNS search suffix is not relevant

### DIFF
--- a/draft-ietf-intarea-proxy-config.md
+++ b/draft-ietf-intarea-proxy-config.md
@@ -354,7 +354,11 @@ Entries that include the wildcard prefix also MUST be treated as if they match
 an FQDN that only contains the string after the prefix, with no subdomain. So,
 an entry "\*.example.com" in the `domains` array of a `proxy-match` rule would match the FQDN "example.com".
 This is done to prevent commonly needing to include both "\*.example.com" and "example.com"
-in the `domains` array of a `proxy-match` rule.
+in the `domains` array of a `proxy-match` rule. Domain name matching in `proxy-match` applies to the
+full authority component of the URI, represented as `reg-name` according to {{Section 3.2.2 of !URI=RFC3986}}.
+Matches are performed against absolute domain names, independent of the client's configured DNS search suffixes.
+Clients MUST NOT apply local DNS suffix search rules when interpreting `domains` entries. A trailing dot (".")
+at the end of a domain name is not required; matches MUST succeed regardless of its presence or absence.
 
 The `subnets` array includes IPv4 and IPv6 address literals, as well as IPv4 and IPv6 address subnets
 written using CIDR notation. Subnet-based destination information can apply to cases where


### PR DESCRIPTION
This addresses following feedback from Philip Lisiecki:

> proxy-match.domains: The examples lack trailing ".".  Are these to be interpreted using the client's default DNS suffixes or be treated as absolute domain names regardless?