### PR TITLE
Unify terminology

### DIFF
--- a/draft-ietf-intarea-proxy-config.md
+++ b/draft-ietf-intarea-proxy-config.md
@@ -38,7 +38,7 @@ normative:
 
 --- abstract
 
-This document defines a mechanism for accessing provisioning domain information
+This document defines a mechanism for accessing Provisioning Domain Additional Information
 associated with a proxy, such as other proxy URIs that support different protocols
 and information about which destinations are accessible using a proxy.
 


### PR DESCRIPTION
This should address terminology feedback from genart review as "provisioning domain", "Provisioning Domain Additional Information" and "PvD" are clearly defined through references.