### PR TITLE
Add reference for IPv6 prefix format

### DIFF
--- a/draft-ietf-intarea-proxy-config.md
+++ b/draft-ietf-intarea-proxy-config.md
@@ -393,7 +393,7 @@ Clients MUST NOT apply local DNS suffix search rules when interpreting `domains`
 string MAY have a trailing dot ("."); it does not affect the matching logic.
 
 The `subnets` array includes IPv4 and IPv6 address literals, as well as IPv4 address subnets
-represented using CIDR notation {{!CIDR=RFC4632}} and IPv6 address prefixes {{Section 2.3 of !RFC4291}}.
+represented using CIDR notation {{!CIDR=RFC4632}} and IPv6 address prefixes {{Section 2.3 of !IPv6-ADDR=RFC4291}}.
 Subnet-based destination information can apply to cases where
 applications are communicating directly with an IP address (without having resolved a DNS name)
 as well as cases where an application resolved a DNS name to a set of IP addresses. Note that


### PR DESCRIPTION
Clarified the description of the `subnets` array to include IPv6 address prefixes and improved explanation of its application.

Addresses TSVART review: https://datatracker.ietf.org/doc/review-ietf-intarea-proxy-config-11-tsvart-telechat-eddy-2026-03-27/